### PR TITLE
fix(JSInterface): 修复 API Level 17 及以上无法正确调用本地 JS 接口的 bug

### DIFF
--- a/Android/jsdemo/src/cn/sharesdk/js/ShareSDKUtils.java
+++ b/Android/jsdemo/src/cn/sharesdk/js/ShareSDKUtils.java
@@ -1,5 +1,6 @@
 package cn.sharesdk.js;
 
+import android.webkit.JavascriptInterface;
 import java.util.ArrayList;
 import java.util.HashMap;
 import cn.sharesdk.framework.Platform;
@@ -81,6 +82,7 @@ public class ShareSDKUtils extends WebViewClient implements Callback {
      *   }
      * }
 	 */
+    @JavascriptInterface
 	public void jsCallback(String seqId, String api, String data, String callback) {
 		// this is in webview core thread, not in ui thread
 		Message msg = new Message();
@@ -90,6 +92,7 @@ public class ShareSDKUtils extends WebViewClient implements Callback {
 	}
 	
 	/** receive js log */
+    @JavascriptInterface
 	public void jsLog(String msg) {
 		Log.w("ShareSDK for JS", msg == null ? "" : msg);
 	}


### PR DESCRIPTION
JELLY_BEAN_MR1 即 API Level 17 以上，必须使用 JavascriptInterface 注解 public 方法，才能被 Javascript 调用。
### Android 文档中有提及：

> Injects the supplied Java object into this WebView. The object is injected into the JavaScript context of the main frame, using the supplied name. This allows the Java object's methods to be accessed from JavaScript. For applications targeted to API level JELLY_BEAN_MR1 and above, only public methods that are annotated with JavascriptInterface can be accessed from JavaScript. For applications targeted to API level JELLY_BEAN or below, all public methods (including the inherited ones) can be accessed, see the important security note below for implications.
